### PR TITLE
Improvements thanks to #1 feedback

### DIFF
--- a/01_XOR/sketch.js
+++ b/01_XOR/sketch.js
@@ -18,13 +18,13 @@ let counter = 0;
 let training = true;
 
 function train() {
-  nn.train(data, 10, finished);
+  nn.train(finished);
 }
 
 function finished() {
   counter++;
   statusP.html('training pass: ' + counter + '<br>framerate: ' + floor(frameRate()));
-  setTimeout(train, 10);
+  train();
 }
 
 let statusP;
@@ -32,6 +32,7 @@ let statusP;
 function setup() {
   createCanvas(400, 400);
   nn = new NeuralNetwork(2, 2, 1);
+  nn.setTrainingData(data);
   train();
   statusP = createP('0');
 }


### PR DESCRIPTION
Some updates thanks to feedback from @nsthorat. I think if we are to create generic `NeuralNetwork` or `Classifier` classes in ml5, a lot of the work will inevitably involve data helper classes so that the end user can work with vanilla arrays and the tensors are all created and managed internally by ml5.

I have a somewhat clear picture in my head of what a `Classifier` class might look like. . .with an `ImageClassifier` subclass with convolutional layers. In this XOR example I'm calling the class `NeuralNetwork` but not sure I love this as a name. Perhaps XOR is not useful as an example for ml5 so this is moot. Maybe we have a `Classifier` and . . `Predictor` (for regression?). Hmmm.  